### PR TITLE
Removed headings to reduce height of cards, images are now links

### DIFF
--- a/src/components/HomePreview.jsx
+++ b/src/components/HomePreview.jsx
@@ -47,7 +47,9 @@ const RecipeDisplay = () => {
                         <div className="recipe card">
                                 <div className="card-image">
                                     <figure className="image">
-                                        <img src={recipe.image} alt={recipe.title} />
+                                        <a href={recipe.instructionsUrl} className="button is-primary ml-4">
+                                            <img src={recipe.image} alt={recipe.title} /> 
+                                        </a>
                                     </figure>
                                 </div>
                                 <div className="card-content">
@@ -61,21 +63,10 @@ const RecipeDisplay = () => {
                                         <p>Calories: {`${recipe.caloriesPerServing.toFixed(2)} kcal`}</p>
                                         <p>Serving Size: {recipe.servingSize}</p>
 
-                                        <h5 className="title is-5">Diet and Health Information:</h5>
                                         <p><strong>Diet Labels:</strong> {recipe.dietLabels.join(', ')}</p>
-                                        <p><strong>Health Labels:</strong> {recipe.healthLabels.join(', ')}</p>
 
-                                        <h5 className="title is-5">Ingredients:</h5>
-                                        <ul>
-                                            {recipe.ingredients.map((ingredient, index) => (
-                                                <li key={index}>{ingredient}</li>
-                                            ))}
-                                        </ul>
 
-                                        <h5 className="title is-5">Preparation:</h5>
-                                        <a href={recipe.instructionsUrl} className="button is-primary ml-4">
-                                            See instructions
-                                        </a>
+
                                         <p className="mt-2 ml-4">Source: <a href={recipe.instructionsUrl} target="_blank" rel="noopener noreferrer" className="has-text-info"><em>{recipe.source}</em></a></p>
                                     </div>
                                 </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -20,7 +20,8 @@ const Home = () => {
                 <HeroBanner backgroundImage="https://upload.wikimedia.org/wikipedia/commons/1/10/Red_Color.jpg" />
             </div>
 
-            <div className="featured-recipes" style={{
+            <div className="featured-recipes" style={{ 
+                paddingLeft: '2vw', paddingRight: '2vw', paddingBottom: '5vh'
             }}>
              <RecipeDisplay />
             </div>


### PR DESCRIPTION
Removed nutrition, ingredient and preparation headings on homepage preview cards
Images of the cards are now links to the recipe