### PR TITLE
Changed space between checkboxes and text

### DIFF
--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -14,7 +14,7 @@ const CheckboxGroup = ({ title, options, selectedOptions, onChange }) => {
                 <label className="checkbox mr-2" key={option}>
                     <input
                         type="checkbox"
-                        value={option}
+                        value={` ${option}`}
                         checked={selectedOptions.includes(option)}
                         onChange={(e) => onChange(e, type)}
                     />
@@ -24,6 +24,5 @@ const CheckboxGroup = ({ title, options, selectedOptions, onChange }) => {
         </div>
     );
 };
-
 
 export default CheckboxGroup;

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -14,12 +14,11 @@ const CheckboxGroup = ({ title, options, selectedOptions, onChange }) => {
                 <label className="checkbox mr-2" key={option}>
                     <input
                         type="checkbox"
-                        value={` ${option}`}
+                        value={option}
                         checked={selectedOptions.includes(option)}
                         onChange={(e) => onChange(e, type)}
                     />
-                    <span style={{ marginLeft: '8px' }}>{option}</span> 
-                    {option}
+                    <span style={{ marginLeft: '4px' }}>{option}</span> 
                 </label>
             ))}
         </div>

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -25,4 +25,5 @@ const CheckboxGroup = ({ title, options, selectedOptions, onChange }) => {
     );
 };
 
+
 export default CheckboxGroup;

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -14,7 +14,7 @@ const CheckboxGroup = ({ title, options, selectedOptions, onChange }) => {
                 <label className="checkbox mr-2" key={option}>
                     <input
                         type="checkbox"
-                        value={ option}
+                        value={` ${option}`}
                         checked={selectedOptions.includes(option)}
                         onChange={(e) => onChange(e, type)}
                     />

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -18,7 +18,7 @@ const CheckboxGroup = ({ title, options, selectedOptions, onChange }) => {
                         checked={selectedOptions.includes(option)}
                         onChange={(e) => onChange(e, type)}
                     />
-                    <span style={{ marginLeft: '2px' }}>{option}</span> 
+                    <span style={{ marginLeft: '3px' }}>{option}</span> 
                 </label>
             ))}
         </div>

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -14,7 +14,7 @@ const CheckboxGroup = ({ title, options, selectedOptions, onChange }) => {
                 <label className="checkbox mr-2" key={option}>
                     <input
                         type="checkbox"
-                        value={` ${option}`}
+                        value={ option}
                         checked={selectedOptions.includes(option)}
                         onChange={(e) => onChange(e, type)}
                     />

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -18,6 +18,7 @@ const CheckboxGroup = ({ title, options, selectedOptions, onChange }) => {
                         checked={selectedOptions.includes(option)}
                         onChange={(e) => onChange(e, type)}
                     />
+                    <span style={{ marginLeft: '8px' }}>{option}</span> 
                     {option}
                 </label>
             ))}

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -18,7 +18,7 @@ const CheckboxGroup = ({ title, options, selectedOptions, onChange }) => {
                         checked={selectedOptions.includes(option)}
                         onChange={(e) => onChange(e, type)}
                     />
-                    <span style={{ marginLeft: '4px' }}>{option}</span> 
+                    <span style={{ marginLeft: '2px' }}>{option}</span> 
                 </label>
             ))}
         </div>


### PR DESCRIPTION
I noticed that the space between the checkboxes and text were a bit off, so I changed the code for the checkbox value to include a leading space. ![Screenshot 2024-09-01 014554](https://github.com/user-attachments/assets/fb9bb0b3-937f-4078-bf98-98b2c17c023a)
